### PR TITLE
Fix: do not try to parse baselines with 0 bytes

### DIFF
--- a/src/butterfly/private/parser.cpp
+++ b/src/butterfly/private/parser.cpp
@@ -507,7 +507,7 @@ namespace butterfly {
                 entities[idx]->set_serializer( &serializers->get( cls ) );
 
                 const std::string bkey = std::to_string(cls);
-                if (baselines.has_key(bkey)) {
+                if (baselines.has_key(bkey) && !baselines.by_key(bkey).value.empty()) {
                     bitstream b(baselines.by_key(bkey).value);
                     entities[idx]->parse( b );
                 }


### PR DESCRIPTION
Butterfly tries to parse baselines with 0 size.

Normally, this should never happen, but there is a bug in the string table decoder that makes this happen iirc.
I fixed this in clarity a long while ago, but I don't want to port the fix.

Fix commit should be this one: https://github.com/skadistats/clarity/commit/414bdb8ca21bf94b77e93549e08b6f0e630677f4

so an equivalent of this

https://github.com/skadistats/clarity/blob/master/src/main/java/skadistats/clarity/processor/stringtables/S2StringTableEmitter.java#L78-L152

should do it.